### PR TITLE
Fix Typo inside `Process your AsciiDoc content` Panel in `index.adoc`

### DIFF
--- a/home/modules/ROOT/pages/index.adoc
+++ b/home/modules/ROOT/pages/index.adoc
@@ -27,7 +27,7 @@ You can also find a side-by-side xref:asciidoc::asciidoc-vs-markdown.adoc[compar
 == xref:asciidoctor::index.adoc[Process your AsciiDoc content]
 
 The AsciiDoc language documentation is primarily about the source you type to compose a document.
-One you're done writing and want to publish your AsciiDoc document, you'll need an AsciiDoc processor.
+Once you're done writing and want to publish your AsciiDoc document, you'll need an AsciiDoc processor.
 That's where Asciidoctor fits in.
 
 xref:asciidoctor::index.adoc[Asciidoctor] is the core AsciiDoc processor.


### PR DESCRIPTION
### The Changes
* Changed the word `One` to `Once` in the second sentence of `Process your AsciiDoc content` Panel.

### Screenshots
![image](https://github.com/asciidoctor/asciidoctor-community-docs/assets/70659536/045507c4-6cd1-4e0f-add9-ef4c7d8c61b7)
_Picture1: A screenshot for context_